### PR TITLE
[#2943] Add stopAndWait method that will stop workers and return a deferred which fires on completion.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def main(args):
     setup_args = dict(
         # metadata
         name="Twisted",
-        version=copyright.version + ".chevah6",
+        version=copyright.version + ".chevah7",
         description="An asynchronous networking framework written in Python",
         author="Twisted Matrix Laboratories",
         author_email="twisted-python@twistedmatrix.com",

--- a/twisted/enterprise/adbapi.py
+++ b/twisted/enterprise/adbapi.py
@@ -10,8 +10,6 @@ import sys
 
 from twisted.internet import threads
 from twisted.python import reflect, log
-from twisted.python.deprecate import deprecated
-from twisted.python.versions import Version
 
 
 
@@ -387,7 +385,7 @@ class ConnectionPool:
         """This should only be called by the shutdown trigger."""
 
         self.shutdownID = None
-        self.threadpool.stop()
+        self.threadpool.stopWithoutWait()
         self.running = False
         for conn in self.connections.values():
             self._close(conn)

--- a/twisted/python/threadpool.py
+++ b/twisted/python/threadpool.py
@@ -209,6 +209,19 @@ class ThreadPool:
             thread.join()
 
 
+    def stopWithoutWait(self):
+        """
+        Post stop request to all working threads and return immediately.
+
+        To wait for workers to terminate before returning call `stop`.
+        """
+        self.joined = True
+
+        while self.workers:
+            self.q.put(WorkerStop)
+            self.workers -= 1
+
+
     def adjustPoolsize(self, minthreads=None, maxthreads=None):
         if minthreads is None:
             minthreads = self.min

--- a/twisted/python/threadpool.py
+++ b/twisted/python/threadpool.py
@@ -226,8 +226,6 @@ class ThreadPool:
         for thread in copy.copy(self.threads):
             yield threads.deferToThread(thread.join)
 
-        defer.returnValue(None)
-
 
     def adjustPoolsize(self, minthreads=None, maxthreads=None):
         if minthreads is None:


### PR DESCRIPTION
## Problem

Current implementation of Twisted `threadpool.stop` will post a stop request to active workers then join and wait for it to terminate.

This is unfortunate for us when using the `adbapi` connection pool with an inaccesible remote server; as it will wait for the network timeout to trigger and block the entire deferred processing.
## Changes

~~Since I don't want to break existing usages of `threadpool` I've decied to add another method which will just post the stop request and return; no longer waiting for the threads to terminate.~~

As you said on IRC, my original solution would lead to a messy cleanup (both in tests and production).

I've revised the code to wait for worker termination on a separate thread, then return a deferred and allow users of `threadpool` and `adbapi` to wait for that when they need to be sure everyting is closed and terminated.

PS: I've done some manual tests on the server and it looks good. There are some minor changes that need to be made in order for you to test it.
## How to test

reviewers @adiroiban 

Please check that my changes make sense.

In order to do a manual test you will need to:
- checkout server master
- change twisted version to `twisted==12.1.0-adi1`
- paver deps

Then from the LM UI:
- make sure you are not connected to the VPN
- start the MySQL database
- refresh the page
- stop the MySQL database
