### PR TITLE
[#3106] Remove alpha characters from version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def main(args):
     setup_args = dict(
         # metadata
         name="Twisted",
-        version=copyright.version + ".chevah9",
+        version=copyright.version + ".9",
         description="An asynchronous networking framework written in Python",
         author="Twisted Matrix Laboratories",
         author_email="twisted-python@twistedmatrix.com",


### PR DESCRIPTION
## Problem

`buildbot` depends also on Twisted and `pip` will not correctly parse the existing Twisted installation version due to alpha characters used for our internal versioning scheme; this results in unistall and download/install of newer (unsupported) version of Twisted.
## Changes

Fixed version to use only digits.
## How to test

reviewers @adiroiban 

This is already released.
